### PR TITLE
feat: [SDK-1313] Update Reference Docs to Use Dokka Versioning Plugin

### DIFF
--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -71,7 +71,9 @@ jobs:
         run: ls code
 
       - name: Generate new docs
-        run: mvn -f code dokka:dokka
+        run: |
+          cd code
+          mvn -f dokka:dokka
 
       - name: list new content
         run: ls -a code/target/dokka

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -57,7 +57,10 @@ jobs:
         run: git checkout main
 
       - name: mvn install
-        run: mvn clean install
+        run: |
+          cd code
+          mvn clean install
+          cd ..
 
       - name: move old versions to code
         run: |

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -43,14 +43,11 @@ jobs:
           rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
           find . -type d -empty -delete
 
-      - name: Move the older directory to temporary workspace
-        run: mv older/* $GITHUB_WORKSPACE/older/
-
       - name: Checkout to main
         run: git checkout main
 
       - name: list workspace content
-        run: ls $GITHUB_WORKSPACE
+        run: ls older
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -68,7 +68,7 @@ jobs:
         run: mvn -f code dokka:dokka
 
       - name: list new content
-        run: cat code/target/dokka/version.json
+        run: ls -a code/target/dokka
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -54,7 +54,11 @@ jobs:
       - name: list workspace content
         run: ls ${{ runner.temp }}/older
 
-      - name:
+      - name: Generate new docs
+        run: mvn -f dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
+
+      - name: list new content
+        run: ls code/target/dokka
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -58,11 +58,6 @@ jobs:
           git fetch --all
           git checkout mdwairi/support-multimodule-versioning
 
-      - name: move old versions to code
-        run: |
-          mv ${{ runner.temp }}/older code/older
-          ls code/older
-
       - name: whats in 4.1.1
         run: ls code/older/4.1.1
 
@@ -72,7 +67,7 @@ jobs:
       - name: Generate new docs
         run: |
           cd code
-          mvn dokka:dokka
+          mvn dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
 
       - name: list new content
         run: ls -a code/target/dokka

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -58,12 +58,6 @@ jobs:
           git fetch --all
           git checkout mdwairi/support-multimodule-versioning
 
-      - name: whats in 4.1.1
-        run: ls code/older/4.1.1
-
-      - name: Whats in code dir
-        run: ls code
-
       - name: Generate new docs
         run: |
           cd code

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -43,12 +43,16 @@ jobs:
           rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
           find . -type d -empty -delete
 
-      - name: List older directory content (debug)
-        run: |
-          pwd
-          cd older
-          ls
-      
-      
-          
-          
+      - name: Move the older directory to temporary workspace
+        run: mv older/* $GITHUB_WORKSPACE/older/
+
+      - name: Checkout to main
+        run: git checkout main
+
+      - name: list workspace content
+        run: ls $GITHUB_WORKSPACE
+
+
+
+
+

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -2,11 +2,6 @@ name: Deploy Reference Documentation
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'SDK Version'
-        required: true
-        type: string
 
 permissions:
   id-token: write
@@ -16,12 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main branch
+      - name: Checkout "main" Branch
         uses: actions/checkout@v4
         with:
           ref: main
 
-      - uses: actions/setup-java@v4
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '21'
@@ -30,61 +26,64 @@ jobs:
         run: |
           git config --global user.email "oss@expediagroup.com"
           git config --global user.name "eg-oss-ci"
-
-      - name: Checkout gh-pages branch
-        run: |
-          git fetch origin mdwairi/refactor-docs-versioning
-          git checkout mdwairi/refactor-docs-versioning
-
-      - name: List directories in gh-pages (debug step)
-        run: |
-          echo "Directories in gh-pages branch:"
-          ls -d */
-
-      - name: Move latest release to the older directory
-        run: |
-          VERSION=$(jq -r '.version' version.json)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
-          find . -type d -empty -delete
-          mkdir -p ${{ runner.temp }}/older
-          mv older/* ${{ runner.temp }}/older
-
-      - name: list older content before checkout
-        run: ls ${{ runner.temp }}/older
-
-      - name: Checkout to main
-        run: |
           git fetch --all
-          git checkout mdwairi/support-multimodule-versioning
 
-      - name: Generate new docs
-        run: |
-          cd code
-          mvn dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
+      - name: Configure "shopt" to Enable Extended Patterns Matching
+        run: shopt -s extglob
 
-      - name: list new content
-        run: ls -a code/target/dokka
-
-      - name: move from target to temp
-        run: |
-          mv code/target/dokka ${{ runner.temp }}/new-docs
-
-      - name: checkout to gh-pages
+      - name: Checkout "gh-pages" Branch
         run: git checkout mdwairi/refactor-docs-versioning
 
-      - name: remove old docs
-        run: rm -rf images older rapid-sdk scripts code styles index.html navigation.html not-found-version.html version.json
+      - name: Store and Extract Latest Docs Version Number
+        run: echo "LATEST_DOCS_VERSION=$(jq -r '.version' version.json)" >> $GITHUB_ENV
+
+      - name: Store Dokka's Files and Directories Names
+        run: |
+          MULTI_VERSIONS_DOKKA_FILES="images|older|rapid-sdk|scripts|styles|index.html|navigation.html|not-found-version.html|version.json"
+          SINGLE_VERSION_DOKKA_FILES="images|rapid-sdk|scripts|styles|index.html|navigation.html|not-found-version.html|version.json"
+          echo "DOKKA_FILES=$DOKKA_FILES" >> $GITHUB_ENV
+          echo "DOKKA_FILES_WITHOUT_OLDER_DIR=$DOKKA_FILES_WITHOUT_OLDER_DIR" >> $GITHUB_ENV
+
+      - name: Move Latest Docs to "older" Directory
+        run: mkdir older/${{ env.LATEST_DOCS_VERSION }} && mv (${{ env.SINGLE_VERSION_DOKKA_FILES }}) older/${{ env.LATEST_DOCS_VERSION }}
+
+      - name: Move "older" Directory to Temporary Workspace
+        run: mv older ${{ runner.temp }}
+
+      - name: Checkout "main" Branch
+        run: git checkout mdwairi/support-multimodule-versioning
+
+      - name: Generate New Release Reference Docs
+        run: mvn -f code dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
+
+      - name: Store and Extract Newly Generated Docs Version Number
+        run: echo "NEW_DOCS_VERSION=$(jq -r '.version' version.json)" >> $GITHUB_ENV
+
+      - name: Move Newly Generated Docs to Temporary Workspace
+        run: mv code/target/dokka ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}
+
+      - name: Checkout "gh-pages" Branch
+        run: git checkout mdwairi/refactor-docs-versioning
+
+      - name: Cleanup Old Docs from Repository Root
+        run: rm -rf (${{ env.MULTI_VERSIONS_DOKKA_FILES }})
 
       - name: list content after removal
         run: ls
 
-      - name: commit new docs
+      - name: Move Newly Generated Docs to the Repository Root
+        run: mv ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}/* .
+
+      - name: inspect final repo shape
         run: |
-          mv ${{ runner.temp }}/new-docs/* .
           ls
-          NEW_DOCS_VERSION=$(jq -r '.version' version.json)
-          echo "NEW_DOCS_VERSION=$NEW_DOCS_VERSION" >> $GITHUB_ENV
+          echo "#####"
+          ls older
+          echo "#####"
+          ls older/3.2.2
+
+      - name: Commit New Release
+        run: |
           git add .
           git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -42,16 +42,16 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
           find . -type d -empty -delete
-          git rm -r --cached "older"
+          mv older/* ${{ runner.temp }}/older
 
       - name: list older content before checkout
-        run: ls older
+        run: ls ${{ runner.temp }}/older
 
       - name: Checkout to main
         run: git checkout main
 
       - name: list workspace content
-        run: ls older
+        run: ls ${{ runner.temp }}/older
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -51,6 +51,19 @@ jobs:
       - name: Store and Extract Newly Generated Docs Version Number
         run: echo "NEW_DOCS_VERSION=$(jq -r '.version' code/target/dokka/version.json)" >> $GITHUB_ENV
 
+      - name: Check New Release Version
+        run: |
+          for dir in ${{ runner.temp }}/older/*; do
+            if [ -d "$dir" ]; then
+              DIR_NAME=$(basename "$dir")
+              if [ "$DIR_NAME" == "${{ env.NEW_DOCS_VERSION }}" ]; then
+                echo "Error: Reference Docs with version ${{env.NEW_DOCS_VERSION }} already exists."
+                echo "Hint: Make sure to update the project version in the pom.xml file"
+                exit 1
+              fi
+            fi
+          done
+
       - name: Move Newly Generated Docs to Temporary Workspace
         run: mv code/target/dokka ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}
 
@@ -79,20 +92,14 @@ jobs:
           git add .
           git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
 
-      - name: Upload modified repository content as artifact
-        uses: actions/upload-artifact@v3
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
         with:
-          name: modified-repo-content
-          path: ./
-
-#      - name: Create Pull Request
-#        uses: peter-evans/create-pull-request@v6
-#        with:
-#          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-#          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
-#          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
-#          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
-#          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
+          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
+          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
+          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -42,6 +42,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
           find . -type d -empty -delete
+          mkdir -p ${{ runner.temp }}/older
           mv older/* ${{ runner.temp }}/older
 
       - name: list older content before checkout

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -61,6 +61,9 @@ jobs:
           mv ${{ runner.temp }}/older code/older
           ls code/older
 
+      - name: whats in 4.1.1
+        run: ls code/older/4.1.1
+
       - name: Whats in code dir
         run: ls code
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -41,9 +41,10 @@ jobs:
           sudo apt-get install -y jq rsync
           VERSION=$(jq -r '.version' version.json)
           mkdir older/$VERSION
-          rsync -av --exclude='older' --exclude='README.md' ./ older/$VERSION
+          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/$VERSION
           cd older 
           ls
+          echo "MOVING INTO THE LATEST VERSION DIRECTORY"
           cd $VERSION
           ls
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -38,12 +38,12 @@ jobs:
 
       - name: Move latest release to the older directory
         run: |
-          sudo apt-get install -y jq rsync
           VERSION=$(jq -r '.version' version.json)
           mkdir older/$VERSION
           rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/$VERSION
-          echo "MOVING INTO THE LATEST VERSION DIRECTORY"
+
+      - name: List older directory content (debug)
+        run: |
           cd older/$VERSION
-          pwd
           ls
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -51,18 +51,18 @@ jobs:
       - name: Store and Extract Newly Generated Docs Version Number
         run: echo "NEW_DOCS_VERSION=$(jq -r '.version' code/target/dokka/version.json)" >> $GITHUB_ENV
 
-      - name: Check New Release Version
-        run: |
-          for dir in ${{ runner.temp }}/older/*; do
-            if [ -d "$dir" ]; then
-              DIR_NAME=$(basename "$dir")
-              if [ "$DIR_NAME" == "${{ env.NEW_DOCS_VERSION }}" ]; then
-                echo "Error: Reference Docs with version ${{env.NEW_DOCS_VERSION }} already exists."
-                echo "Hint: Make sure to update the project version in the pom.xml file"
-                exit 1
-              fi
-            fi
-          done
+#      - name: Check New Release Version
+#        run: |
+#          for dir in ${{ runner.temp }}/older/*; do
+#            if [ -d "$dir" ]; then
+#              DIR_NAME=$(basename "$dir")
+#              if [ "$DIR_NAME" == "${{ env.NEW_DOCS_VERSION }}" ]; then
+#                echo "Error: Reference Docs with version ${{env.NEW_DOCS_VERSION }} already exists."
+#                echo "Hint: Make sure to update the project version in the pom.xml file"
+#                exit 1
+#              fi
+#            fi
+#          done
 
       - name: Move Newly Generated Docs to Temporary Workspace
         run: mv code/target/dokka ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}
@@ -72,9 +72,6 @@ jobs:
 
       - name: Cleanup Old Docs from Repository Root
         run: rm -rf code images older rapid-sdk scripts styles index.html navigation.html not-found-version.html version.json
-
-      - name: list content after removal
-        run: ls
 
       - name: Move Newly Generated Docs to the Repository Root
         run: mv ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}/* .
@@ -87,19 +84,19 @@ jobs:
           echo "#####"
           ls older/3.2.2
 
-      - name: Commit New Release
-        run: |
-          git add .
-          git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
+#      - name: Commit New Release
+#        run: |
+#          git add .
+#          git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
-          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
-          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
-          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
+#      - name: Create Pull Request
+#        uses: peter-evans/create-pull-request@v6
+#        with:
+#          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+#          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
+#          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
+#          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
+#          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -41,8 +41,8 @@ jobs:
         run: |
           MULTI_VERSIONS_DOKKA_FILES="images|older|rapid-sdk|scripts|styles|index.html|navigation.html|not-found-version.html|version.json"
           SINGLE_VERSION_DOKKA_FILES="images|rapid-sdk|scripts|styles|index.html|navigation.html|not-found-version.html|version.json"
-          echo "DOKKA_FILES=$DOKKA_FILES" >> $GITHUB_ENV
-          echo "DOKKA_FILES_WITHOUT_OLDER_DIR=$DOKKA_FILES_WITHOUT_OLDER_DIR" >> $GITHUB_ENV
+          echo "MULTI_VERSIONS_DOKKA_FILES=$MULTI_VERSIONS_DOKKA_FILES" >> $GITHUB_ENV
+          echo "SINGLE_VERSION_DOKKA_FILES=$SINGLE_VERSION_DOKKA_FILES" >> $GITHUB_ENV
 
       - name: Move Latest Docs to "older" Directory
         run: mkdir older/${{ env.LATEST_DOCS_VERSION }} && mv (${{ env.SINGLE_VERSION_DOKKA_FILES }}) older/${{ env.LATEST_DOCS_VERSION }}

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -52,7 +52,7 @@ jobs:
         run: mvn -f code dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
 
       - name: Store and Extract Newly Generated Docs Version Number
-        run: echo "NEW_DOCS_VERSION=$(jq -r '.version' version.json)" >> $GITHUB_ENV
+        run: echo "NEW_DOCS_VERSION=$(jq -r '.version' code/target/dokka/version.json)" >> $GITHUB_ENV
 
       - name: Move Newly Generated Docs to Temporary Workspace
         run: mv code/target/dokka ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -40,7 +40,8 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' version.json)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/${{ env.VERSION }}/
+          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/${{ env.VERSION }}/
+          find . -type d -empty -delete
 
       - name: List older directory content (debug)
         run: |

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -45,5 +45,8 @@ jobs:
       - name: List older directory content (debug)
         run: |
           pwd
+          ls
+          cd older
+          ls
           
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -16,70 +16,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
+      - name: Checkout main branch
+        uses: actions/checkout@v4
         with:
-          distribution: 'corretto'
-          java-version: '21'
+          ref: main
 
-      - run: mvn -f code dokka:dokka
-
-      - name: Download resources
-        run: |
-          git fetch origin main
-          mkdir -p ${{ runner.temp }}/resources
-          cp .github/workflows/resources/docs-home-template.html ${{ runner.temp }}/resources/docs-home-template.html
-
-      - name: Prepare for deployment
+      - name: Configure Git
         run: |
           git config --global user.email "oss@expediagroup.com"
           git config --global user.name "eg-oss-ci"
-          
-          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          
-          git fetch --all
-          mkdir -p docs/${{ github.event.inputs.version }}
-          mv code/target/dokka/* docs/${{ github.event.inputs.version }}
-          git add .
-          git commit -m "chore: publishing docs for version ${{ github.event.inputs.version }}"
-          
-          BRANCH_EXISTS=$(git ls-remote --heads origin gh-pages | wc -l)
-          if [ "$BRANCH_EXISTS" -eq 0 ]; then
-            git checkout --orphan gh-pages
-          else
-            git checkout gh-pages
-            git pull origin gh-pages
-          fi
-          
-          git checkout $CURRENT_BRANCH -- docs
-          mv docs/* .
 
-      - name: Build Index Page
+      - name: Checkout gh-pages branch
         run: |
-          rm -rf docs code
-          touch index.html
-          LIST_ITEMS=""
-          for dir in $(ls -d */ | sort -rV); do
-            if [ "$dir" != "${{ github.event.inputs.version }}/" ] && [ "$dir" != "latest/" ]; then
-              LIST_ITEMS="${LIST_ITEMS}<li><a href=\"${dir}\">${dir}</a></li>"
-            fi
-          done
-          sed -e "s#{{list_items}}#${LIST_ITEMS}#g" \
-             -e "s#{{latest_version}}#${{ github.event.inputs.version }}#g" \
-             ${{ runner.temp }}/resources/docs-home-template.html > index.html
-          ln -sfn ./${{ github.event.inputs.version }} ./latest 
+          git fetch origin mdwairi/refactor-docs-versioning
+          git checkout mdwairi/refactor-docs-versioning
 
-      - name: Commit
+      - name: List directories in gh-pages (debug step)
         run: |
-          git add .
-          git commit -m "chore: publishing docs for version ${{ github.event.inputs.version }}"
+          echo "Directories in gh-pages branch:"
+          ls -d */
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          commit-message: "chore: publishing docs for version ${{ github.event.inputs.version }}"
-          body: "This PR adds the reference documentation for version ${{ github.event.inputs.version }}."
-          title: "chore: reference docs update for version ${{ github.event.inputs.version }}"
-          branch: "docs-update-${{ github.event.inputs.version }}"
+      - name: Move latest release to the older directory
+        run: |
+          sudo apt-get install -y jq rsync
+          VERSION=$(jq -r '.version' config.json)
+          mkdir older/$VERSION
+          rsync -av --exclude='older' --exclude='README.md' ./ older/$VERSION
+          cd older 
+          ls
+          cd $VERSION
+          ls
+          

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -44,7 +44,7 @@ jobs:
           find . -type d -empty -delete
 
       - name: Checkout to main
-        run: git checkout main
+        run: git checkout main -- older
 
       - name: list workspace content
         run: ls older

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -46,6 +46,9 @@ jobs:
       - name: List older directory content (debug)
         run: |
           pwd
+          cd older
           ls
+      
+      
           
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -56,12 +56,6 @@ jobs:
       - name: Checkout to main
         run: git checkout main
 
-      - name: mvn install
-        run: |
-          cd code
-          mvn clean install
-          cd ..
-
       - name: move old versions to code
         run: |
           mv ${{ runner.temp }}/older code/older
@@ -73,7 +67,7 @@ jobs:
       - name: Generate new docs
         run: |
           cd code
-          mvn -f dokka:dokka
+          mvn dokka:dokka
 
       - name: list new content
         run: ls -a code/target/dokka

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -42,9 +42,8 @@ jobs:
           VERSION=$(jq -r '.version' version.json)
           mkdir older/$VERSION
           rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/$VERSION
-          cd older 
-          ls
           echo "MOVING INTO THE LATEST VERSION DIRECTORY"
-          cd $VERSION
+          cd older/$VERSION
+          pwd
           ls
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -28,9 +28,6 @@ jobs:
           git config --global user.name "eg-oss-ci"
           git fetch --all
 
-      - name: Configure "shopt" to Enable Extended Patterns Matching
-        run: shopt -s extglob
-
       - name: Checkout "gh-pages" Branch
         run: git checkout mdwairi/refactor-docs-versioning
 
@@ -61,7 +58,7 @@ jobs:
         run: git checkout mdwairi/refactor-docs-versioning
 
       - name: Cleanup Old Docs from Repository Root
-        run: rm -rf images older rapid-sdk scripts styles index.html navigation.html not-found-version.html version.json
+        run: rm -rf code images older rapid-sdk scripts styles index.html navigation.html not-found-version.html version.json
 
       - name: list content after removal
         run: ls

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -66,6 +66,35 @@ jobs:
       - name: list new content
         run: ls -a code/target/dokka
 
+      - name: move from target to temp
+        run: |
+          mv code/target/dokka ${{ runner.temp }}/new-docs
+
+      - name: checkout to gh-pages
+        run: git checkout mdwairi/refactor-docs-versioning
+
+      - name: remove old docs
+        run: rm -rf images older rapid-sdk script styles index.html navigation.html not-found-version.html version.json
+
+      - name: commit new docs
+        run: |
+          NEW_DOCS_VERSION=$(jq -r '.version' version.json)
+          echo "NEW_DOCS_VERSION=NEW_DOCS_VERSION" >> $GITHUB_ENV
+          mv ${{ runner.temp }}/new-docs .
+          git add .
+          git commit -m "chore: publishing docs for version $NEW_DOCS_VERSION"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
+          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
+          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
+          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
+
+
+
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -52,10 +52,14 @@ jobs:
         run: git checkout main
 
       - name: list workspace content
-        run: ls ${{ runner.temp }}/older
+        run: |
+          ls ${{ runner.temp }}/older
+          ls ${{ runner.temp }}/older/3.2.2
 
       - name: move old versions to code
-        run: mv ${{ runner.temp }}/older code/older
+        run: |
+          mv ${{ runner.temp }}/older code/older
+          ls code/older
 
       - name: Generate new docs
         run: mvn -f code dokka:dokka

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -44,7 +44,6 @@ jobs:
 
       - name: List older directory content (debug)
         run: |
-          cd older/${{ env.VERSION }}
-          ls
+          pwd
           
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -51,15 +51,13 @@ jobs:
       - name: Checkout to main
         run: git checkout main
 
-      - name: list workspace content
-        run: |
-          ls ${{ runner.temp }}/older
-          ls ${{ runner.temp }}/older/3.2.2
-
       - name: move old versions to code
         run: |
           mv ${{ runner.temp }}/older code/older
           ls code/older
+
+      - name: Whats in code dir
+        run: ls code
 
       - name: Generate new docs
         run: mvn -f code dokka:dokka

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -40,18 +40,18 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' version.json)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          mkdir -p $GITHUB_WORKSPACE/older/$VERSION
-          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ $GITHUB_WORKSPACE/older/$VERSION/
+          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
           find . -type d -empty -delete
+          git rm -r --cached "older"
 
-      - name: List older content before checkout
-        run: ls $GITHUB_WORKSPACE/older
+      - name: list older content before checkout
+        run: ls older
 
       - name: Checkout to main
         run: git checkout main
 
-      - name: List workspace content
-        run: ls $GITHUB_WORKSPACE/older
+      - name: list workspace content
+        run: ls older
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -37,15 +37,10 @@ jobs:
       - name: Store and Extract Latest Docs Version Number
         run: echo "LATEST_DOCS_VERSION=$(jq -r '.version' version.json)" >> $GITHUB_ENV
 
-      - name: Store Dokka's Files and Directories Names
+      - name: Move Latest Docs to "older/${LATEST_DOCS_VERSION}" Directory
         run: |
-          MULTI_VERSIONS_DOKKA_FILES="images|older|rapid-sdk|scripts|styles|index.html|navigation.html|not-found-version.html|version.json"
-          SINGLE_VERSION_DOKKA_FILES="images|rapid-sdk|scripts|styles|index.html|navigation.html|not-found-version.html|version.json"
-          echo "MULTI_VERSIONS_DOKKA_FILES=$MULTI_VERSIONS_DOKKA_FILES" >> $GITHUB_ENV
-          echo "SINGLE_VERSION_DOKKA_FILES=$SINGLE_VERSION_DOKKA_FILES" >> $GITHUB_ENV
-
-      - name: Move Latest Docs to "older" Directory
-        run: mkdir older/${{ env.LATEST_DOCS_VERSION }} && mv (${{ env.SINGLE_VERSION_DOKKA_FILES }}) older/${{ env.LATEST_DOCS_VERSION }}
+          mkdir older/${{ env.LATEST_DOCS_VERSION }} 
+          mv images rapid-sdk scripts styles index.html navigation.html not-found-version.html version.json older/${{ env.LATEST_DOCS_VERSION }}
 
       - name: Move "older" Directory to Temporary Workspace
         run: mv older ${{ runner.temp }}
@@ -66,7 +61,7 @@ jobs:
         run: git checkout mdwairi/refactor-docs-versioning
 
       - name: Cleanup Old Docs from Repository Root
-        run: rm -rf (${{ env.MULTI_VERSIONS_DOKKA_FILES }})
+        run: rm -rf images older rapid-sdk scripts styles index.html navigation.html not-found-version.html version.json
 
       - name: list content after removal
         run: ls

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -54,6 +54,8 @@ jobs:
       - name: list workspace content
         run: ls ${{ runner.temp }}/older
 
+      - name:
+
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -39,12 +39,13 @@ jobs:
       - name: Move latest release to the older directory
         run: |
           VERSION=$(jq -r '.version' version.json)
-          mkdir older/${{ VERSION }}
-          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/${{ VERSION }}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          mkdir older/${{ env.VERSION }}
+          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/${{ env.VERSION }}
 
       - name: List older directory content (debug)
         run: |
-          cd older/${{ VERSION }}
+          cd older/${{ env.VERSION }}
           ls
           
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -47,7 +47,7 @@ jobs:
         run: ls older
 
       - name: Checkout to main
-        run: git checkout main -- older
+        run: git checkout main
 
       - name: list workspace content
         run: ls older

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Checkout to main
         run: git checkout main
 
+      - name: mvn install
+        run: mvn clean install
+
       - name: move old versions to code
         run: |
           mv ${{ runner.temp }}/older code/older

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -63,7 +63,7 @@ jobs:
         run: mvn -f code dokka:dokka
 
       - name: list new content
-        run: ls code/target/dokka
+        run: cat code/target/dokka/version.json
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -16,10 +16,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main branch
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
         with:
-          ref: main
+          distribution: 'corretto'
+          java-version: '21'
 
       - name: Configure Git
         run: |

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -84,7 +84,7 @@ jobs:
           mv ${{ runner.temp }}/new-docs/* .
           ls
           NEW_DOCS_VERSION=$(jq -r '.version' version.json)
-          echo "NEW_DOCS_VERSION=NEW_DOCS_VERSION" >> $GITHUB_ENV
+          echo "NEW_DOCS_VERSION=$NEW_DOCS_VERSION" >> $GITHUB_ENV
           git add .
           git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -76,11 +76,14 @@ jobs:
       - name: remove old docs
         run: rm -rf images older rapid-sdk script styles index.html navigation.html not-found-version.html version.json
 
+      - name: list content after removal
+        run: ls
+
       - name: commit new docs
         run: |
+          mv ${{ runner.temp }}/new-docs .
           NEW_DOCS_VERSION=$(jq -r '.version' version.json)
           echo "NEW_DOCS_VERSION=NEW_DOCS_VERSION" >> $GITHUB_ENV
-          mv ${{ runner.temp }}/new-docs .
           git add .
           git commit -m "chore: publishing docs for version $NEW_DOCS_VERSION"
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -54,7 +54,9 @@ jobs:
         run: ls ${{ runner.temp }}/older
 
       - name: Checkout to main
-        run: git checkout main
+        run: |
+          git fetch --all
+          git checkout mdwairi/support-multimodule-versioning
 
       - name: move old versions to code
         run: |

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -55,7 +55,7 @@ jobs:
         run: ls ${{ runner.temp }}/older
 
       - name: Generate new docs
-        run: mvn -f dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
+        run: mvn -f code dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
 
       - name: list new content
         run: ls code/target/dokka

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -46,7 +46,5 @@ jobs:
         run: |
           pwd
           ls
-          cd older
-          ls
           
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -40,17 +40,18 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' version.json)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
+          mkdir -p $GITHUB_WORKSPACE/older/$VERSION
+          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ $GITHUB_WORKSPACE/older/$VERSION/
           find . -type d -empty -delete
 
-      - name: list older content before checkout
-        run: ls older
+      - name: List older content before checkout
+        run: ls $GITHUB_WORKSPACE/older
 
       - name: Checkout to main
         run: git checkout main
 
-      - name: list workspace content
-        run: ls older
+      - name: List workspace content
+        run: ls $GITHUB_WORKSPACE/older
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -16,7 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Move latest release to the older directory
         run: |
           sudo apt-get install -y jq rsync
-          VERSION=$(jq -r '.version' config.json)
+          VERSION=$(jq -r '.version' version.json)
           mkdir older/$VERSION
           rsync -av --exclude='older' --exclude='README.md' ./ older/$VERSION
           cd older 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -43,6 +43,9 @@ jobs:
           rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
           find . -type d -empty -delete
 
+      - name: list older content before checkout
+        run: ls older
+
       - name: Checkout to main
         run: git checkout main -- older
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -54,8 +54,11 @@ jobs:
       - name: list workspace content
         run: ls ${{ runner.temp }}/older
 
+      - name: move old versions to code
+        run: mv ${{ runner.temp }}/older code/older
+
       - name: Generate new docs
-        run: mvn -f code dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
+        run: mvn -f code dokka:dokka
 
       - name: list new content
         run: ls code/target/dokka

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -39,11 +39,12 @@ jobs:
       - name: Move latest release to the older directory
         run: |
           VERSION=$(jq -r '.version' version.json)
-          mkdir older/$VERSION
-          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/$VERSION
+          mkdir older/${{ VERSION }}
+          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/${{ VERSION }}
 
       - name: List older directory content (debug)
         run: |
-          cd older/$VERSION
+          cd older/${{ VERSION }}
           ls
+          
           

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -29,74 +29,66 @@ jobs:
           git fetch --all
 
       - name: Checkout "gh-pages" Branch
-        run: git checkout mdwairi/refactor-docs-versioning
+        run: git checkout gh-pages
 
-      - name: Store and Extract Latest Docs Version Number
+      - name: Extract and Store Latest Live Docs Version Number
         run: echo "LATEST_DOCS_VERSION=$(jq -r '.version' version.json)" >> $GITHUB_ENV
 
-      - name: Move Latest Docs to "older/${LATEST_DOCS_VERSION}" Directory
+      - name: Move Latest Docs to the "older" Directory (Archiving latest live release)
         run: |
           mkdir older/${{ env.LATEST_DOCS_VERSION }} 
           mv images rapid-sdk scripts styles index.html navigation.html not-found-version.html version.json older/${{ env.LATEST_DOCS_VERSION }}
 
-      - name: Move "older" Directory to Temporary Workspace
+      - name: Move the "older" Directory to a Temporary Workspace
         run: mv older ${{ runner.temp }}
 
       - name: Checkout "main" Branch
-        run: git checkout mdwairi/support-multimodule-versioning
+        run: git checkout main
 
       - name: Generate New Release Reference Docs
         run: mvn -f code dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older
 
-      - name: Store and Extract Newly Generated Docs Version Number
+      - name: Extract and Store Newly Generated Docs Version Number
         run: echo "NEW_DOCS_VERSION=$(jq -r '.version' code/target/dokka/version.json)" >> $GITHUB_ENV
 
-#      - name: Check New Release Version
-#        run: |
-#          for dir in ${{ runner.temp }}/older/*; do
-#            if [ -d "$dir" ]; then
-#              DIR_NAME=$(basename "$dir")
-#              if [ "$DIR_NAME" == "${{ env.NEW_DOCS_VERSION }}" ]; then
-#                echo "Error: Reference Docs with version ${{env.NEW_DOCS_VERSION }} already exists."
-#                echo "Hint: Make sure to update the project version in the pom.xml file"
-#                exit 1
-#              fi
-#            fi
-#          done
+      - name: Check the New Release Version
+        run: |
+          for dir in ${{ runner.temp }}/older/*; do
+            if [ -d "$dir" ]; then
+              DIR_NAME=$(basename "$dir")
+              if [ "$DIR_NAME" == "${{ env.NEW_DOCS_VERSION }}" ]; then
+                echo "Error: Reference Docs with version ${{env.NEW_DOCS_VERSION }} already exists."
+                echo "Hint: Make sure to update the project version in the pom.xml file"
+                exit 1
+              fi
+            fi
+          done
 
-      - name: Move Newly Generated Docs to Temporary Workspace
+      - name: Move the Newly Generated Docs to a Temporary Workspace
         run: mv code/target/dokka ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}
 
       - name: Checkout "gh-pages" Branch
-        run: git checkout mdwairi/refactor-docs-versioning
+        run: git checkout gh-pages
 
-      - name: Cleanup Old Docs from Repository Root
+      - name: Cleanup Old Docs from the Repository's Root
         run: rm -rf code images older rapid-sdk scripts styles index.html navigation.html not-found-version.html version.json
 
       - name: Move Newly Generated Docs to the Repository Root
         run: mv ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}/* .
 
-      - name: inspect final repo shape
+      - name: Commit the New Release
         run: |
-          ls
-          echo "#####"
-          ls older
-          echo "#####"
-          ls older/3.2.2
+          git add .
+          git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
 
-#      - name: Commit New Release
-#        run: |
-#          git add .
-#          git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
-
-#      - name: Create Pull Request
-#        uses: peter-evans/create-pull-request@v6
-#        with:
-#          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-#          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
-#          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
-#          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
-#          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
+          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
+          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
+          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' version.json)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/${{ env.VERSION }}/
+          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' --remove-source-files ./ older/$VERSION/
           find . -type d -empty -delete
 
       - name: List older directory content (debug)

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -74,14 +74,15 @@ jobs:
         run: git checkout mdwairi/refactor-docs-versioning
 
       - name: remove old docs
-        run: rm -rf images older rapid-sdk script styles index.html navigation.html not-found-version.html version.json
+        run: rm -rf images older rapid-sdk scripts code styles index.html navigation.html not-found-version.html version.json
 
       - name: list content after removal
         run: ls
 
       - name: commit new docs
         run: |
-          mv ${{ runner.temp }}/new-docs .
+          mv ${{ runner.temp }}/new-docs/* .
+          ls
           NEW_DOCS_VERSION=$(jq -r '.version' version.json)
           echo "NEW_DOCS_VERSION=NEW_DOCS_VERSION" >> $GITHUB_ENV
           git add .

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -79,14 +79,20 @@ jobs:
           git add .
           git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+      - name: Upload modified repository content as artifact
+        uses: actions/upload-artifact@v3
         with:
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
-          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
-          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
-          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
+          name: modified-repo-content
+          path: ./
+
+#      - name: Create Pull Request
+#        uses: peter-evans/create-pull-request@v6
+#        with:
+#          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+#          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
+#          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
+#          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
+#          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
 
 
 

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -40,8 +40,7 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' version.json)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          mkdir older/${{ env.VERSION }}
-          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/${{ env.VERSION }}
+          rsync -av --exclude='older' --exclude='.git' --exclude='README.md' ./ older/${{ env.VERSION }}/
 
       - name: List older directory content (debug)
         run: |

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -86,7 +86,7 @@ jobs:
           NEW_DOCS_VERSION=$(jq -r '.version' version.json)
           echo "NEW_DOCS_VERSION=NEW_DOCS_VERSION" >> $GITHUB_ENV
           git add .
-          git commit -m "chore: publishing docs for version $NEW_DOCS_VERSION"
+          git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -587,7 +587,7 @@
                     <pluginsConfiguration>
                         <org.jetbrains.dokka.versioning.VersioningPlugin>
                             <version>${project.version}</version>
-                            <olderVersionsDir>${project.basedir}/older</olderVersionsDir>
+                            <olderVersionsDir>older</olderVersionsDir>
                         </org.jetbrains.dokka.versioning.VersioningPlugin>
                     </pluginsConfiguration>
                     <suppressInheritedMembers>true</suppressInheritedMembers>
@@ -815,7 +815,7 @@
                             <pluginsConfiguration>
                                 <org.jetbrains.dokka.versioning.VersioningPlugin>
                                     <version>${project.version}</version>
-                                    <olderVersionsDir>${project.basedir}/older</olderVersionsDir>
+                                    <olderVersionsDir>older</olderVersionsDir>
                                 </org.jetbrains.dokka.versioning.VersioningPlugin>
                             </pluginsConfiguration>
                         </configuration>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -587,7 +587,7 @@
                     <pluginsConfiguration>
                         <org.jetbrains.dokka.versioning.VersioningPlugin>
                             <version>${project.version}</version>
-                            <olderVersionsDir>older</olderVersionsDir>
+                            <olderVersionsDir>${dokka-old-versions.location}</olderVersionsDir>
                         </org.jetbrains.dokka.versioning.VersioningPlugin>
                     </pluginsConfiguration>
                     <suppressInheritedMembers>true</suppressInheritedMembers>
@@ -815,7 +815,7 @@
                             <pluginsConfiguration>
                                 <org.jetbrains.dokka.versioning.VersioningPlugin>
                                     <version>${project.version}</version>
-                                    <olderVersionsDir>older</olderVersionsDir>
+                                    <olderVersionsDir>${dokka-old-versions.location}</olderVersionsDir>
                                 </org.jetbrains.dokka.versioning.VersioningPlugin>
                             </pluginsConfiguration>
                         </configuration>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -587,7 +587,7 @@
                     <pluginsConfiguration>
                         <org.jetbrains.dokka.versioning.VersioningPlugin>
                             <version>${project.version}</version>
-                            <olderVersionsDir>${project.basedir}</olderVersionsDir>
+                            <olderVersionsDir>${project.basedir}/older</olderVersionsDir>
                         </org.jetbrains.dokka.versioning.VersioningPlugin>
                     </pluginsConfiguration>
                     <suppressInheritedMembers>true</suppressInheritedMembers>
@@ -810,7 +810,7 @@
                             <pluginsConfiguration>
                                 <org.jetbrains.dokka.versioning.VersioningPlugin>
                                     <version>${project.version}</version>
-                                    <olderVersionsDir>${project.basedir}</olderVersionsDir>
+                                    <olderVersionsDir>${project.basedir}/older</olderVersionsDir>
                                 </org.jetbrains.dokka.versioning.VersioningPlugin>
                             </pluginsConfiguration>
                         </configuration>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -73,6 +73,7 @@
         <ktlint-plugin.version>3.2.0</ktlint-plugin.version>
         <jacoco-plugin.version>0.8.12</jacoco-plugin.version>
         <dokka-plugin.version>1.9.20</dokka-plugin.version>
+        <dokka-old-versions.location>1.9.20</dokka-old-versions.location>
         <properties.maven.plugin.version>1.2.1</properties.maven.plugin.version>
         <maven.licence.plugin.version>4.5</maven.licence.plugin.version>
         <flatten.maven.plugin.version>1.6.0</flatten.maven.plugin.version>
@@ -577,7 +578,18 @@
                             <artifactId>kotlin-as-java-plugin</artifactId>
                             <version>${dokka-plugin.version}</version>
                         </plugin>
+                        <plugin>
+                            <groupId>org.jetbrains.dokka</groupId>
+                            <artifactId>versioning-plugin</artifactId>
+                            <version>${dokka-plugin.version}</version>
+                        </plugin>
                     </dokkaPlugins>
+                    <pluginsConfiguration>
+                        <org.jetbrains.dokka.versioning.VersioningPlugin>
+                            <version>${project.version}</version>
+                            <olderVersionsDir>${dokka-old-versions.location}</olderVersionsDir>
+                        </org.jetbrains.dokka.versioning.VersioningPlugin>
+                    </pluginsConfiguration>
                     <suppressInheritedMembers>true</suppressInheritedMembers>
                 </configuration>
                 <executions>
@@ -789,7 +801,18 @@
                                     <artifactId>kotlin-as-java-plugin</artifactId>
                                     <version>${dokka-plugin.version}</version>
                                 </plugin>
+                                <plugin>
+                                    <groupId>org.jetbrains.dokka</groupId>
+                                    <artifactId>versioning-plugin</artifactId>
+                                    <version>${dokka-plugin.version}</version>
+                                </plugin>
                             </dokkaPlugins>
+                            <pluginsConfiguration>
+                                <org.jetbrains.dokka.versioning.VersioningPlugin>
+                                    <version>${project.version}</version>
+                                    <olderVersionsDir>${dokka-old-versions.location}</olderVersionsDir>
+                                </org.jetbrains.dokka.versioning.VersioningPlugin>
+                            </pluginsConfiguration>
                         </configuration>
                         <executions>
                             <execution>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -639,6 +639,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jetbrains.dokka</groupId>
+            <artifactId>versioning-plugin</artifactId>
+            <version>${dokka-plugin.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.expediagroup</groupId>
     <artifactId>rapid-sdk</artifactId>
-    <version>4.1.2</version>
+    <version>4.1.3</version>
     <name>EG Rapid SDK for Java</name>
     <description>EG Rapid SDK v4.1.2</description>
     <url>https://github.com/ExpediaGroup/rapid-java-sdk</url>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -587,7 +587,7 @@
                     <pluginsConfiguration>
                         <org.jetbrains.dokka.versioning.VersioningPlugin>
                             <version>${project.version}</version>
-                            <olderVersionsDir>${dokka-old-versions.location}</olderVersionsDir>
+                            <olderVersionsDir>${project.basedir}</olderVersionsDir>
                         </org.jetbrains.dokka.versioning.VersioningPlugin>
                     </pluginsConfiguration>
                     <suppressInheritedMembers>true</suppressInheritedMembers>
@@ -810,7 +810,7 @@
                             <pluginsConfiguration>
                                 <org.jetbrains.dokka.versioning.VersioningPlugin>
                                     <version>${project.version}</version>
-                                    <olderVersionsDir>${dokka-old-versions.location}</olderVersionsDir>
+                                    <olderVersionsDir>${project.basedir}</olderVersionsDir>
                                 </org.jetbrains.dokka.versioning.VersioningPlugin>
                             </pluginsConfiguration>
                         </configuration>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -73,7 +73,7 @@
         <ktlint-plugin.version>3.2.0</ktlint-plugin.version>
         <jacoco-plugin.version>0.8.12</jacoco-plugin.version>
         <dokka-plugin.version>1.9.20</dokka-plugin.version>
-        <dokka-old-versions.location>1.9.20</dokka-old-versions.location>
+        <dokka-old-versions.location/> <!-- passed as a property when running dokka:dokka-->
         <properties.maven.plugin.version>1.2.1</properties.maven.plugin.version>
         <maven.licence.plugin.version>4.5</maven.licence.plugin.version>
         <flatten.maven.plugin.version>1.6.0</flatten.maven.plugin.version>
@@ -638,11 +638,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.jetbrains.dokka</groupId>
-            <artifactId>versioning-plugin</artifactId>
-            <version>${dokka-plugin.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.expediagroup</groupId>
     <artifactId>rapid-sdk</artifactId>
-    <version>4.1.3</version>
+    <version>4.1.2</version>
     <name>EG Rapid SDK for Java</name>
     <description>EG Rapid SDK v4.1.2</description>
     <url>https://github.com/ExpediaGroup/rapid-java-sdk</url>


### PR DESCRIPTION
## Summary
Ticket: https://jira.expedia.biz/browse/SDK-1313

Updated Dokka plugin to use the `versioning-plugin`. This enables rendering a dropdown menu to switch between different reference docs versions.

> [!CAUTION]
> This PR introduces many changes to the workflow that automates the reference docs generation. 
>
> We should merge this dependency [PR](https://github.com/ExpediaGroup/rapid-java-sdk/pull/89) first, which refactors the `gh-pages` branch structure to adhere to the expected structure in the new workflow.

## Description
Updated the `pom.xml` to apply Dokka versioning plugin. It's worth mentioning that there's a problem in recognizing these new plugin's configurations by the IDEs. So you may see the `pom.xml` file complaining about incorrect configurations. [Related GitHub Issue](https://github.com/Kotlin/dokka/issues/3387).

Another big change is refactoring the `generate-docs-site.yml` workflow file. The new Dokka configurations need to be aware of all previous docs versions before attempting to generate the new version.

**Summary of changes in workflow file:**
1. Removed the `SDK Version` input. The version is now read from the `pom.xml` directly.
2. The plugin is now expecting the location of the older versions directory to be passed as a maven property 
`-Ddokka-old-versions.location`
3. Added a version-check step which aborts the action if the newly-released docs has a same version number as a previously released version.
4. Whenever this action is triggered, it will remove all repository's content and push the newly generated docs.

> [!NOTE]
> All movements using `mv` or deletions using `rm` are strictly scoped to Dokka's generated files and directories to avoid unintended changes on unrelated files.