### PR TITLE
chore: remove pom extraction and overwrite steps

### DIFF
--- a/.github/workflows/run-examples.yaml
+++ b/.github/workflows/run-examples.yaml
@@ -55,14 +55,6 @@ jobs:
         with:
           java-version: ${{ inputs.jdk }}
           distribution: ${{ inputs.distribution }}
-      - name: Extract POM from JAR
-        if: ${{ inputs.sdk_generation_workflow_run_id != '' }}
-        working-directory: examples
-        run: unzip -o jar/original-rapid-sdk-${{ inputs.sdk_version }}.jar -d jar/extracted
-      - name: Overwrite SDK POM file
-        if: ${{ inputs.sdk_generation_workflow_run_id != '' }}
-        working-directory: examples
-        run: mv jar/extracted/META-INF/maven/com.expediagroup/rapid-sdk/pom.xml sdk/pom.xml
       - name: Install SDK into local repository
         if: ${{ inputs.sdk_generation_workflow_run_id != '' }}
         working-directory: examples/sdk


### PR DESCRIPTION
Refactored the workflow by eliminating steps for extracting and overwriting the POM file from the SDK JAR. This simplifies the process and reduces unnecessary file operations, while maintaining the installation of the SDK into the local repository.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- 

### :link: Related Issues
- 
