### PR TITLE
chore: fix method and classes naming

### DIFF
--- a/examples/src/main/java/com/expediagroup/sdk/rapid/examples/RapidSdkDemoApplication.java
+++ b/examples/src/main/java/com/expediagroup/sdk/rapid/examples/RapidSdkDemoApplication.java
@@ -3,7 +3,7 @@ package com.expediagroup.sdk.rapid.examples;
 import com.expediagroup.sdk.rapid.examples.salesprofiles.DefaultRapidPartnerProfile;
 import com.expediagroup.sdk.rapid.examples.scenarios.booking.AsyncSingleRoomBookScenario;
 import com.expediagroup.sdk.rapid.examples.scenarios.booking.MultiRoomHoldAndResumeBookScenario;
-import com.expediagroup.sdk.rapid.examples.scenarios.booking.SingleRoomBookScenario;
+import com.expediagroup.sdk.rapid.examples.scenarios.booking.CompletePaymentSessionSingleRoomBookScenario;
 import com.expediagroup.sdk.rapid.examples.scenarios.content.GetPropertyContentInAdditionalLanguageScenario;
 import com.expediagroup.sdk.rapid.examples.scenarios.content.GetPropertyContentScenario;
 import com.expediagroup.sdk.rapid.examples.scenarios.geography.GetListOfRegionNamesScenario;
@@ -23,12 +23,14 @@ import com.expediagroup.sdk.rapid.examples.scenarios.shopping.GetPaymentOptionsO
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.ExecutionException;
+
 
 public class RapidSdkDemoApplication {
 
     private static final Logger logger = LoggerFactory.getLogger(RapidSdkDemoApplication.class);
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
 
         logger.info("=======================================================================================");
         logger.info("=======================================================================================");
@@ -69,9 +71,9 @@ public class RapidSdkDemoApplication {
             2. Checking room prices for the property
             3. Booking the property
         */
-        SingleRoomBookScenario singleRoomBookScenario = new SingleRoomBookScenario();
-        singleRoomBookScenario.setProfile(new DefaultRapidPartnerProfile());
-        singleRoomBookScenario.run();
+        CompletePaymentSessionSingleRoomBookScenario completePaymentSessionSingleRoomBookScenario = new CompletePaymentSessionSingleRoomBookScenario();
+        completePaymentSessionSingleRoomBookScenario.setProfile(new DefaultRapidPartnerProfile());
+        completePaymentSessionSingleRoomBookScenario.run();
 
         /*  Run Async Single Room Book Scenario using the default profile
             This scenario demonstrates the following:

--- a/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/RapidScenario.java
+++ b/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/RapidScenario.java
@@ -2,9 +2,11 @@ package com.expediagroup.sdk.rapid.examples.scenarios;
 
 import com.expediagroup.sdk.rapid.examples.salesprofiles.RapidPartnerSalesProfile;
 
+import java.util.concurrent.ExecutionException;
+
 public interface RapidScenario {
 
     void setProfile(RapidPartnerSalesProfile rapidPartnerSalesProfile);
 
-    void run();
+    void run() throws ExecutionException, InterruptedException;
 }

--- a/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/booking/CompletePaymentSessionSingleRoomBookScenario.java
+++ b/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/booking/CompletePaymentSessionSingleRoomBookScenario.java
@@ -15,10 +15,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
-public class SingleRoomBookScenario implements RapidScenario {
+public class CompletePaymentSessionSingleRoomBookScenario implements RapidScenario {
 
-    private static final Logger logger = LoggerFactory.getLogger(SingleRoomBookScenario.class);
+    private static final Logger logger = LoggerFactory.getLogger(CompletePaymentSessionSingleRoomBookScenario.class);
     private ShopService shopService = new ShopService();
     private RapidPartnerSalesProfile rapidPartnerSalesProfile;
 
@@ -28,12 +29,12 @@ public class SingleRoomBookScenario implements RapidScenario {
     }
 
     @Override
-    public void run() {
+    public void run() throws ExecutionException, InterruptedException {
 
         // Shopping for properties
         logger.info("Getting property availability for test property: {}", Constants.TEST_PROPERTY_ID);
 
-        List<Property> propertyAvailabilityList = shopService.getSingleRoomPropertiesAvailability(this.rapidPartnerSalesProfile).getData();
+        List<Property> propertyAvailabilityList = shopService.asyncGetSingleRoomPropertiesAvailability(this.rapidPartnerSalesProfile).get().getData();
 
         if (propertyAvailabilityList == null || propertyAvailabilityList.isEmpty()) {
             throw new IllegalStateException("No property availability found for the test property.");

--- a/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/booking/RegisterPaymentSessionScenario.java
+++ b/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/booking/RegisterPaymentSessionScenario.java
@@ -15,8 +15,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
-public class CompletePaymentSessionScenario implements RapidScenario {
+class CompletePaymentSessionScenario implements RapidScenario {
 
     private static final Logger logger = LoggerFactory.getLogger(CompletePaymentSessionScenario.class);
     private ShopService shopService = new ShopService();
@@ -28,12 +29,12 @@ public class CompletePaymentSessionScenario implements RapidScenario {
     }
 
     @Override
-    public void run() {
+    public void run() throws ExecutionException, InterruptedException {
 
         // Shopping for properties
         logger.info("Getting property availability for test property: {}", Constants.TEST_PROPERTY_ID);
 
-        List<Property> propertyAvailabilityList = shopService.getSingleRoomPropertiesAvailability(this.rapidPartnerSalesProfile).getData();
+        List<Property> propertyAvailabilityList = shopService.asyncGetSingleRoomPropertiesAvailability(this.rapidPartnerSalesProfile).get().getData();
 
         if (propertyAvailabilityList == null || propertyAvailabilityList.isEmpty()) {
             throw new IllegalStateException("No property availability found for the test property.");

--- a/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/booking/SingleRoomBookScenario.java
+++ b/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/booking/SingleRoomBookScenario.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class SingleRoomBookScenario implements RapidScenario {
 
-    private static final Logger logger = LoggerFactory.getLogger(CompletePaymentSessionSingleRoomBookScenario.class);
+    private static final Logger logger = LoggerFactory.getLogger(SingleRoomBookScenario.class);
     private ShopService shopService = new ShopService();
     private RapidPartnerSalesProfile rapidPartnerSalesProfile;
 

--- a/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/booking/SingleRoomBookScenario.java
+++ b/examples/src/main/java/com/expediagroup/sdk/rapid/examples/scenarios/booking/SingleRoomBookScenario.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class SingleRoomBookScenario implements RapidScenario {
 
-    private static final Logger logger = LoggerFactory.getLogger(SingleRoomBookScenario.class);
+    private static final Logger logger = LoggerFactory.getLogger(CompletePaymentSessionSingleRoomBookScenario.class);
     private ShopService shopService = new ShopService();
     private RapidPartnerSalesProfile rapidPartnerSalesProfile;
 


### PR DESCRIPTION
## Situation
Inconsistency in a few classes and method names causes the examples module to fail on the compilation step.

## Task
Refactor inconsistent namings and make sure the examples module compiles and runs as expected.

## Action
* **Duplicate `SingleRoomBookScenario ` Classes**: Renamed the duplicate `SingleRoomBookScenario ` class in `CompletePaymentSessionScenario.java` file to `CompletePaymentSessionSingleRoomBookScenario `.
* **Non-Existing `getSingleRoomPropertiesAvailability ` Method Usage**: Updated the method name to its new updated name `asyncGetSingleRoomPropertiesAvailability ` wherever used and used `.get()` on its returned future.
* **Async Runs Exception Handling**: Added `ExecutionException` and `InterruptedException` exceptions to method signatures where suitable. These exceptions could be thrown due to the `async` execution of methods where they return `CompletableFuture` instances.

## Result
The `examples` module now compiles and runs as expected.