### PR TITLE
chore: update template to use custom return types

### DIFF
--- a/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/client.mustache
+++ b/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/client.mustache
@@ -113,12 +113,12 @@ class {{clientClassname}}Client private constructor(clientConfiguration: RapidCl
                 * @throws ExpediaGroupApi{{.}}Exception
             {{/dataTypes}}
         {{/exceptionDataTypes}}
-        * @return a [Response] object with a body of type {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
+        * @return a [Response] object with a body of type {{#customReturnType}}{{{returnType}}}{{/customReturnType}}{{^returnType}}Nothing{{/returnType}}
         */
-        fun execute(operation: {{operationIdCamelCase}}Operation) : {{#returnType}}Response<{{{returnType}}}>{{/returnType}}{{^returnType}}EmptyResponse{{/returnType}} {
-            {{#returnType}}
+        fun execute(operation: {{operationIdCamelCase}}Operation) : {{#customReturnType}}Response<{{{returnType}}}>{{/customReturnType}}{{^returnType}}EmptyResponse{{/returnType}} {
+        {{#customReturnType}}
                 return execute<{{#bodyParam}}{{dataType}}{{/bodyParam}}{{^hasBodyParam}}Nothing{{/hasBodyParam}}, {{{returnType}}}>(operation)
-            {{/returnType}}
+            {{/customReturnType}}
             {{^returnType}}
                 return executeWithEmptyResponse<{{#bodyParam}}{{dataType}}{{/bodyParam}}{{^hasBodyParam}}Nothing{{/hasBodyParam}}>(operation)
             {{/returnType}}
@@ -133,18 +133,18 @@ class {{clientClassname}}Client private constructor(clientConfiguration: RapidCl
                 * @throws ExpediaGroupApi{{.}}Exception
             {{/dataTypes}}
         {{/exceptionDataTypes}}
-        * @return a [CompletableFuture<Response>] object with a body of type {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
+        * @return a [CompletableFuture<Response>] object with a body of type {{#customReturnType}}{{{returnType}}}{{/customReturnType}}{{^returnType}}Nothing{{/returnType}}
         */
-        fun executeAsync(operation: {{operationIdCamelCase}}Operation) : CompletableFuture<{{#returnType}}Response<{{{returnType}}}>{{/returnType}}{{^returnType}}EmptyResponse{{/returnType}}> {
-        {{#returnType}}
+        fun executeAsync(operation: {{operationIdCamelCase}}Operation) : CompletableFuture<{{#customReturnType}}Response<{{{returnType}}}>{{/customReturnType}}{{^returnType}}EmptyResponse{{/returnType}}> {
+        {{#customReturnType}}
             return executeAsync<{{#bodyParam}}{{dataType}}{{/bodyParam}}{{^hasBodyParam}}Nothing{{/hasBodyParam}}, {{{returnType}}}>(operation)
-        {{/returnType}}
+        {{/customReturnType}}
         {{^returnType}}
             return executeAsyncWithEmptyResponse<{{#bodyParam}}{{dataType}}{{/bodyParam}}{{^hasBodyParam}}Nothing{{/hasBodyParam}}>(operation)
         {{/returnType}}
         }
 
-        private suspend {{^isKotlin}}inline {{/isKotlin}}fun {{^isKotlin}}k{{/isKotlin}}{{operationId}}WithResponse({{>client/apiParamsDecleration}}): {{#returnType}}Response<{{{returnType}}}>{{/returnType}}{{^returnType}}Response<Nothing>{{/returnType}} {
+        private suspend {{^isKotlin}}inline {{/isKotlin}}fun {{^isKotlin}}k{{/isKotlin}}{{operationId}}WithResponse({{>client/apiParamsDecleration}}): {{#customReturnType}}Response<{{{returnType}}}>{{/customReturnType}}{{^returnType}}Response<Nothing>{{/returnType}} {
             {{#hasNonBodyParams}}
                 val params =  {{operationIdCamelCase}}OperationParams(
                 {{#nonBodyParams}}
@@ -179,7 +179,7 @@ class {{clientClassname}}Client private constructor(clientConfiguration: RapidCl
                     * @throws ExpediaGroupApi{{.}}Exception
                 {{/dataTypes}}
             {{/exceptionDataTypes}}
-            * @return {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
+            * @return {{#customReturnType}}{{{returnType}}}{{/customReturnType}}{{^returnType}}Nothing{{/returnType}}
             */
             @Throws(
                 {{#exceptionDataTypes}}
@@ -191,7 +191,7 @@ class {{clientClassname}}Client private constructor(clientConfiguration: RapidCl
             )
             @JvmOverloads
             @Deprecated("Use execute method instead", ReplaceWith("execute(operation: {{operationIdCamelCase}}Operation)"))
-            fun {{operationId}}({{>client/apiParamsDecleration}}) : {{{returnType}}}{{^returnType}}Nothing{{/returnType}} {
+            fun {{operationId}}({{>client/apiParamsDecleration}}) : {{#customReturnType}}{{{returnType}}}{{/customReturnType}}{{^returnType}}Nothing{{/returnType}} {
                 return {{operationId}}WithResponse({{>client/apiParamsPassed}}).data
             }
 
@@ -206,7 +206,7 @@ class {{clientClassname}}Client private constructor(clientConfiguration: RapidCl
                     * @throws ExpediaGroupApi{{.}}Exception
                 {{/dataTypes}}
             {{/exceptionDataTypes}}
-            * @return a [Response] object with a body of type {{{returnType}}}{{^returnType}}Nothing{{/returnType}}
+            * @return a [Response] object with a body of type {{#customReturnType}}{{{returnType}}}{{/customReturnType}}{{^returnType}}Nothing{{/returnType}}
             */
             @Throws(
                 {{#exceptionDataTypes}}
@@ -218,7 +218,7 @@ class {{clientClassname}}Client private constructor(clientConfiguration: RapidCl
             )
             @JvmOverloads
             @Deprecated("Use execute method instead", ReplaceWith("execute(operation: {{operationIdCamelCase}}Operation)"))
-            fun {{operationId}}WithResponse({{>client/apiParamsDecleration}}) : {{#returnType}}Response<{{{returnType}}}>{{/returnType}}{{^returnType}}Response<Nothing>{{/returnType}} {
+            fun {{operationId}}WithResponse({{>client/apiParamsDecleration}}) : {{#customReturnType}}Response<{{{returnType}}}>{{/customReturnType}}{{^returnType}}Response<Nothing>{{/returnType}} {
                 try {
                     return GlobalScope.future(Dispatchers.IO) {
                         k{{operationId}}WithResponse({{>client/apiParamsPassed}})


### PR DESCRIPTION
Enhanced the client.mustache template to integrate the usage of custom return types based on the `customReturnType` flag. This provides greater flexibility in defining the response types for different operations.

