### PR TITLE
fix: dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - Dependabot
 
   - package-ecosystem: maven
-    directory: "/"
+    directory: "/examples"
     schedule:
       interval: daily
       time: "11:30"
@@ -26,9 +26,3 @@ updates:
       - ExpediaGroup/openworld-committers
     labels:
       - Dependabot
-    ignore:
-      - dependency-name: "*"
-        versions: [ "*" ]
-        update-types: [ "all" ]
-        directories:
-          - "/code"


### PR DESCRIPTION
# Situation  
Dependabot was unable to detect and update our configured dependency files effectively. 
```
The property '#/updates/1/ignore/0' contains additional properties ["directories"] outside of the schema when none are allowed
The property '#/updates/1/ignore/0/update-types/0' value "all" did not match one of the following values: version-update:semver-major, version-update:semver-minor, version-update:semver-patch
```

# Task  
- Fix the issue by configuring maven updates to be applied to the `examples` folder only.

# Action  
- Fixed invalid properties in `.github/dependabot.yml`
- Updated Maven config to target `examples/**` only

# Testing  
Post-merge, verify that Dependabot updates:  
- Maven dependencies in the expected folders (excluding `code`).  
- GitHub Actions dependencies in `.github/workflows`.  

# Results  
- Dependabot configuration passes validation
- Maven updates correctly scoped to `examples`

# Notes  
**Internal Ticket:** SDK-1573