### PR TITLE
chore: remove isSpace from docs tree

### DIFF
--- a/docs/tree.yml
+++ b/docs/tree.yml
@@ -1,5 +1,4 @@
 path: products/rapid/sdk/java/index.md
-isSpace: true
 children:
   - path: products/rapid/sdk/java/quick-start.md
   - path: products/rapid/sdk/java/usage-examples/index.md


### PR DESCRIPTION
# Situation
`isSpace` is set to true in docs tree

# Task
remove `isSpace`

# Action
remove `isSpace`

# Testing
Verified in internal DevHub repo.

# Results
`isSpace` removed

