### PR TITLE
SDK-1591 Adding documentation for the new OkHttpClient configuration

### DIFF
--- a/docs/java/logging.md
+++ b/docs/java/logging.md
@@ -157,6 +157,13 @@ Example log messages at the DEBUG level:
 17:40:08.510 [OkHttp https://test.ean.com/...] DEBUG com.expediagroup.sdk.core.client.OkHttpEventListener - ExpediaSDK: Sending request headers end for transaction-id: [aff4c00d-6f79-4690-8f60-dd1aaccbfaee]
 ```
 
+{% messageCard type="info" %}
+{% messageCardHeader %}
+Note
+{% /messageCardHeader %}
+The debug level logs mentioned above are only available when using the SDK client with the built-in HTTP client. If you configure the SDK client with a custom HTTP client, you must implement this logging within your HTTP client instance.
+{% /messageCard %}
+
 ## Traceability
 
 The SDK generates a unique `transaction ID` for every API call, which is useful for troubleshooting issues by tracing requests end-to-end. The transactions IDs are added to the request and response headers, and they are logged in error messages in case of exceptions.

--- a/docs/java/okhttpclient.md
+++ b/docs/java/okhttpclient.md
@@ -1,0 +1,70 @@
+---
+intro: Introducing Configurable HTTP Client
+shortTitle: Introducing Configurable HTTP Client
+title: Introducing Configurable HTTP Client
+tags:
+  - new
+---
+
+# Introducing Configurable HTTP Client
+
+## What is a Configurable HTTP Client?
+
+The RAPID SDK is built on top of an OkHttpClient that is not open for you to configure and tune. Lately, we've come to
+realize your need to tune and optimize the HTTP client to your needs. So in order to give developers using the RAPID SDK
+more control over the underlying HTTP client of the SDK, we're introducing a new builder which you can use to pass your
+own HTTP Client for the SDK to use internally.
+
+Using this builder, you can build an HTTP client with you own configurations and pass it to the SDK, or even pass a
+client you're already using in your application.
+
+{% messageCard type="info" %}
+{% messageCardHeader %}
+Note
+{% /messageCardHeader %}
+This feature is available in the `rapid-sdk` v5.2.0 and later.
+{% /messageCard %}
+
+## Why use a Configurable HTTP Client?
+
+A configurable HTTP client will benefit you in the following ways:
+
+- **Optimization:** Fine-tune the client for better performance, such as connection pooling, timeouts, and retries.
+- **Integration:** Use an existing HTTP client that is already configured and tested within your application.
+
+## How to configure your HTTP client?
+
+To configure your HTTP client, you need to create an instance of `OkHttpClient` and pass it to the `RapidClient` builder.
+
+#### 1. Create an instance of `OkHttpClient` with your configurations. You may use an existing instance or create a new one. For example:
+```java
+OkHttpClient customClient = new OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build();
+```
+For more information on configuring the `OkHttpClient`, refer to the [OkHttp documentation](https://square.github.io/okhttp/).
+
+#### 2. Pass the `OkHttpClient` instance to the `RapidClient` builder `builderWithHttpClient`
+```java
+RapidClient rapidClient = RapidClient.builderWithHttpClient()
+        .key("YOUR_API_KEY")
+        .secret("YOUR_API_SECRET")
+        .okHttpClient(customClient)
+        .build();
+```
+
+#### 3. Make API Calls: Use the configured rapidClient to make API calls as usual
+```java
+GetAvailabilityOperationParams getAvailabilityOperationParams = GetAvailabilityOperationParams.builder()
+        .checkin("YYYY-MM-DD")
+        .checkout("YYYY-MM-DD")
+        .currency("USD")
+        .language("en_US")
+        /* ... */
+        .build();
+
+GetAvailabilityOperation operation = new GetAvailabilityOperation(params);
+Response<List<Property>> response = rapidClient.execute(operation);
+```

--- a/docs/java/quick-start.md
+++ b/docs/java/quick-start.md
@@ -142,6 +142,42 @@ RapidClient rapidClient =
 ```
 
 {% /expandoListItem %}
+
+{% expandoListItem %}
+{% expandoHeading %}
+(Optional) 2.3. Configure OkHttp client
+{% /expandoHeading %}
+
+The service client can be configured with a custom `OkHttpClient` instance. This allows you to fine-tune the HTTP client 
+for better performance, such as connection pooling, timeouts, and concurrency handling.
+{% br/ %}
+
+### 2.3.1. Create and configure an OkHttpClient instance
+Create an instance of OkHttpClient with your custom configurations:
+
+```java
+OkHttpClient customClient = new OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build();
+```
+
+For more information on configuring the `OkHttpClient`, refer to the [OkHttp documentation](https://square.github.io/okhttp/).
+
+{% br/ %}
+
+### 2.3.2. Pass the OkHttpClient instance to the RapidClient builder
+
+```java
+RapidClient rapidClient = RapidClient.builderWithHttpClient()
+        .key("YOUR_API_KEY")
+        .secret("YOUR_API_SECRET")
+        .okHttpClient(customClient)
+        .build();
+```
+
+{% /expandoListItem %}
 {% /expandoList %}
 
 ## 3. Make API calls


### PR DESCRIPTION
# Situation
We need documentation in developers hub around the new ability to configure an okhttp client in the rapid sdk.

# Task
Add documentation in developers hub around the new ability to configure an okhttp client in the rapid sdk.

# Action
1. Added a new page to introduce the new functionality.
2. Added a new collapsed section under the quick start guide around configuring the okhttp client
3. Added a note under log levels in the logging doc that clarifies that this feature won't be available for custom okhttp clients.

# Testing
Verify the generated pr view

# Results
-

# Notes
-
