### PR TITLE
fix: generate docs site script

### DIFF
--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -71,7 +71,7 @@ jobs:
         run: git checkout gh-pages
 
       - name: Cleanup Old Docs from the Repository's Root
-        run: rm -rf code images older rapid-sdk scripts styles index.html navigation.html not-found-version.html version.json
+        run: rm -rf code images older rapid-sdk scripts styles ui-kit index.html navigation.html not-found-version.html version.json
 
       - name: Move Newly Generated Docs to the Repository Root
         run: mv ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}/* .


### PR DESCRIPTION
# Situation
Deploy docs site fail to complete https://github.com/ExpediaGroup/rapid-java-sdk/actions/runs/12259912781/job/34203235363#step:16:11

# Task
Fix the action

# Action
fixed the action by adding a folder need to be cleaned before generating new site

# Testing
manually

# Results
action should run 

# Notes
Internal ticket: SDK-1630