### PR TITLE
fix: update okhttpclient and links pages after feedback

### DIFF
--- a/docs/java/links.md
+++ b/docs/java/links.md
@@ -1,14 +1,12 @@
 ---
-intro: Introducing Links
-shortTitle: Introducing Links
-title: Introducing Links
+intro: Using Links
+shortTitle: Links
+title: Using Links
 tags:
   - new
 ---
 
-# Introducing Links
-
-## What is a Link?
+# Using Links
 
 RapidAPI consists of several API resources that enable you to create an end-to-end booking experience for your
 travelers.
@@ -27,10 +25,10 @@ operations, bypassing the typical setup process and significantly enhancing effi
 {% messageCardHeader %}
 Note
 {% /messageCardHeader %}
-This feature is available in the `rapid-sdk` v4.3.0 and later.
+This feature is available in the `rapid-sdk` v5.1.0 and later.
 {% /messageCard %}
 
-## Why to use a Link?
+## Benefits of using Links
 
 `Link` is a convenient way to navigate through the Rapid API operations, without having to manually create the next
 operation. You can extract a `Link` from the response of the previous operation and use it to create the next operation.
@@ -46,10 +44,10 @@ A link will benefit you in the following ways:
 
 ## How to use a Link?
 
-To get a `Link`, you need to extract it from the previous `Operation` response.
+In an operation response, look for the returned links, use the link to build the next suitable operation.
 Then, you can create the next `Operation` from the `Link` and execute it with the `RapidClient`.
 
-For example, you can create a `Link` from the response of a `GetAvailabilityOperation` and use it in creating
+For example, you can create a `PriceCheckOperationLink` from the response of a `GetAvailabilityOperation` and use it in creating
 a `PriceCheckOperation`:
 
 ```java
@@ -67,8 +65,8 @@ if (!(property instanceof PropertyAvailability)) {
 
 PropertyAvailability propertyAvailability = (PropertyAvailability) property;
 
-// 3a. Extract the priceCheck link from PropertyAvailability operation (Here, we select the first rate for the first room, then get the priceCheck link)
-Link priceCheckLink = propertyAvailability.getRooms().get(0).getRates().get(0).getBedGroups().entrySet().stream().findFirst().get().getValue().getLinks().getPriceCheck();
+// 3a. Extract the PriceCheckOperationLink from PropertyAvailability operation (Here, we select the first rate for the first room, then get the PriceCheckOperationLink)
+PriceCheckOperationLink priceCheckLink = propertyAvailability.getRooms().get(0).getRates().get(0).getBedGroups().entrySet().stream().findFirst().get().getValue().getLinks().getPriceCheck();
 
 // 3b. Create the needed context for the PriceCheckOperation
 PriceCheckOperationContext priceCheckOperationContext = PriceCheckOperationContext.builder().customerIp("1.2.3.4").build(); // fill the context as needed
@@ -79,7 +77,7 @@ Response<RoomPriceCheck> roomPriceCheckResponse = rapidClient.execute(priceCheck
 // ...
 ```
 
-Another example would be to create a `Link` from the response of a `PriceCheckOperation` and use it in creating a
+Another example would be to create a `PostItineraryOperationLink` from the response of a `PriceCheckOperation` and use it in creating a
 booking.
 
 ```java
@@ -87,7 +85,7 @@ booking.
 RoomPriceCheck roomPriceCheck = roomPriceCheckResponse.getData(); // from the previous step
 
 // 2a. Extract the Link from the RoomPriceCheck
-Link postItineraryLink = roomPriceCheck.getLinks().getBook();
+PostItineraryOperationLink postItineraryLink = roomPriceCheck.getLinks().getBook();
 
 // 2b. Create the needed context for the PostItineraryOperation
 PostItineraryOperationContext postItineraryOperationContext = PostItineraryOperationContext.builder().customerIp("1.2.3.4").build(); // fill the context as needed

--- a/docs/java/okhttpclient.md
+++ b/docs/java/okhttpclient.md
@@ -1,17 +1,16 @@
 ---
-intro: Introducing Configurable HTTP Client
-shortTitle: Introducing Configurable HTTP Client
-title: Introducing Configurable HTTP Client
+intro: Configurable HTTP Client
+shortTitle: Configurable HTTP Client
+title: Configurable HTTP Client
 tags:
   - new
 ---
 
-# Introducing Configurable HTTP Client
+# Configurable HTTP Client
 
-The RAPID SDK is built on top of an OkHttpClient that is not open for you to configure and tune. Lately, we've come to
-realize your need to tune and optimize the HTTP client to your needs. So in order to give developers using the Rapid SDK
-more control over the underlying HTTP client of the SDK, we're introducing a new builder which you can use to pass your
-own HTTP client for the SDK to use internally.
+The SDK uses an underlying HTTP client to execute API calls. In order to give developers using the Rapid SDK
+more control over the HTTP client of the SDK, a builder is provided which you can use to pass your
+own HTTP client for the SDK to use.
 
 Using this builder, you can build an HTTP client with your own configurations and pass it to the SDK, or even pass a
 client you're already using in your application.
@@ -51,9 +50,9 @@ For more information on configuring the `OkHttpClient`, refer to the [OkHttp doc
 #### 2. Pass the `OkHttpClient` instance to the `RapidClient` builder `builderWithHttpClient`
 ```java
 RapidClient rapidClient = RapidClient.builderWithHttpClient()
+        .okHttpClient(customClient)
         .key("YOUR_API_KEY")
         .secret("YOUR_API_SECRET")
-        .okHttpClient(customClient)
         .build();
 ```
 

--- a/docs/java/quick-start.md
+++ b/docs/java/quick-start.md
@@ -171,9 +171,9 @@ For more information on configuring the `OkHttpClient`, refer to the [OkHttp doc
 
 ```java
 RapidClient rapidClient = RapidClient.builderWithHttpClient()
+        .okHttpClient(customClient)
         .key("YOUR_API_KEY")
         .secret("YOUR_API_SECRET")
-        .okHttpClient(customClient)
         .build();
 ```
 

--- a/docs/java/usage-examples/hold-resume-booking.md
+++ b/docs/java/usage-examples/hold-resume-booking.md
@@ -39,9 +39,9 @@ if (!(property instanceof PropertyAvailability)) {
 }
 
 PropertyAvailability propertyAvailability = (PropertyAvailability) property;
-Link propertyAvailabilityLink = propertyAvailability.getRooms().get(0).getRates().get(0).getBedGroups().entrySet().stream().findFirst().get().getValue().getLinks().getPriceCheck(); // selecting the first rate for the first room
+PriceCheckOperationLink priceCheckOperationLink = propertyAvailability.getRooms().get(0).getRates().get(0).getBedGroups().entrySet().stream().findFirst().get().getValue().getLinks().getPriceCheck(); // selecting the first rate for the first room
 PriceCheckOperationContext priceCheckOperationContext = PriceCheckOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PriceCheckOperation priceCheckOperation = new PriceCheckOperation(propertyAvailabilityLink, priceCheckOperationContext);
+PriceCheckOperation priceCheckOperation = new PriceCheckOperation(priceCheckOperationLink, priceCheckOperationContext);
 Response<RoomPriceCheck> response = rapidClient.execute(priceCheckOperation);
 RoomPriceCheck roomPriceCheck = response.getData();
 ```
@@ -121,17 +121,17 @@ CreateItineraryRequest createItineraryRequest(boolean hold) {
 
 #### Create itinerary
 ```java
-Link postItineraryLink = roomPriceCheck.getLinks().getBook(); // from the previous step
+PostItineraryOperationLink postItineraryOperationLink = roomPriceCheck.getLinks().getBook(); // from the previous step
 PostItineraryOperationContext postItineraryOperationContext = PostItineraryOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PostItineraryOperation itineraryCreationOperation = new PostItineraryOperation(postItineraryLink, postItineraryOperationContext, createItineraryRequest(true));
+PostItineraryOperation itineraryCreationOperation = new PostItineraryOperation(postItineraryOperationLink, postItineraryOperationContext, createItineraryRequest(true));
 Response<ItineraryCreation> response = rapidClient.execute(itineraryCreationOperation);
 ItineraryCreation itineraryCreation = response.getData();
 ```
 
 #### Resume on-hold booking
 ```java
-Link resumeBookingLink = itineraryCreation.getLinks().getResume(); // from the previous step
+PutResumeBookingOperationLink putResumeBookingOperationLink = itineraryCreation.getLinks().getResume(); // from the previous step
 PutResumeBookingOperationContext putResumeBookingOperationContext = PutResumeBookingOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PutResumeBookingOperation itineraryResumeOperation = new PutResumeBookingOperation(resumeBookingLink, putResumeBookingOperationContext);
+PutResumeBookingOperation itineraryResumeOperation = new PutResumeBookingOperation(putResumeBookingOperationLink, putResumeBookingOperationContext);
 rapidClient.execute(itineraryResumeOperation);
 ```

--- a/docs/java/usage-examples/instant-booking.md
+++ b/docs/java/usage-examples/instant-booking.md
@@ -42,9 +42,9 @@ if (!(property instanceof PropertyAvailability)) {
 }
 
 PropertyAvailability propertyAvailability = (PropertyAvailability) property;
-Link propertyAvailabilityLink = propertyAvailability.getRooms().get(0).getRates().get(0).getBedGroups().entrySet().stream().findFirst().get().getValue().getLinks().getPriceCheck(); // selecting the first rate for the first room
+PriceCheckOperationLink priceCheckOperationLink = propertyAvailability.getRooms().get(0).getRates().get(0).getBedGroups().entrySet().stream().findFirst().get().getValue().getLinks().getPriceCheck(); // selecting the first rate for the first room
 PriceCheckOperationContext priceCheckOperationContext = PriceCheckOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PriceCheckOperation priceCheckOperation = new PriceCheckOperation(propertyAvailabilityLink, priceCheckOperationContext);
+PriceCheckOperation priceCheckOperation = new PriceCheckOperation(priceCheckOperationLink, priceCheckOperationContext);
 Response<RoomPriceCheck> response = rapidClient.execute(priceCheckOperation);
 RoomPriceCheck roomPriceCheck = response.getData();
 
@@ -130,9 +130,9 @@ CreateItineraryRequest createItineraryRequest(boolean hold) {
 The primary itinerary method of the Booking API creates a reservation for the selected property, room, rate, and occupancy. Payment information, including billing/cardholder contact information, is provided directly within the request. See [here](products/rapid/lodging/booking) for more details.
 
 ```java
-Link postItineraryLink = roomPriceCheck.getLinks().getBook(); // from the previous step
+PostItineraryOperationLink postItineraryOperationLink = roomPriceCheck.getLinks().getBook(); // from the previous step
 PostItineraryOperationContext postItineraryOperationContext = PostItineraryOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PostItineraryOperation itineraryCreationOperation = new PostItineraryOperation(postItineraryLink, postItineraryOperationContext, createItineraryRequest(false));
+PostItineraryOperation itineraryCreationOperation = new PostItineraryOperation(postItineraryOperationLink, postItineraryOperationContext, createItineraryRequest(false));
 Response<ItineraryCreation> response = rapidClient.execute(itineraryCreationOperation);
 ItineraryCreation itineraryCreationResponse = response.getData();
 ```

--- a/docs/java/usage-examples/psd2-booking.md
+++ b/docs/java/usage-examples/psd2-booking.md
@@ -39,8 +39,8 @@ if (!(property instanceof PropertyAvailability)) {
 }
 
 PropertyAvailability propertyAvailability = (PropertyAvailability) property;
-Link propertyAvailabilityLink = propertyAvailability.getRooms().get(0).getRates().get(0).getBedGroups().entrySet().stream().findFirst().get().getValue().getLinks().getPriceCheck(); // selecting the first rate for the first room
-PriceCheckOperation priceCheckOperation = new PriceCheckOperation(propertyAvailabilityLink);
+PriceCheckOperationLink priceCheckOperationLink = propertyAvailability.getRooms().get(0).getRates().get(0).getBedGroups().entrySet().stream().findFirst().get().getValue().getLinks().getPriceCheck(); // selecting the first rate for the first room
+PriceCheckOperation priceCheckOperation = new PriceCheckOperation(priceCheckOperationLink);
 Response<RoomPriceCheck> response = rapidClient.execute(priceCheckOperation);
 RoomPriceCheck roomPriceCheck = response.getData();
 ```
@@ -113,9 +113,9 @@ PaymentSessionsRequest createPaymentSessionRequest() {
 
 #### Create payment session
 ```java
-Link paymentSessionLink = roomPriceCheck.getLinks().getPaymentSession();
+PostPaymentSessionsOperationLink postPaymentSessionsOperationLink = roomPriceCheck.getLinks().getPaymentSession();
 PostPaymentSessionsOperationContext postPaymentSessionsOperationContext = PostPaymentSessionsOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PostPaymentSessionsOperation paymentSessionsOperation = new PostPaymentSessionsOperation(paymentSessionLink, postPaymentSessionsOperationContext, createPaymentSessionRequest());
+PostPaymentSessionsOperation paymentSessionsOperation = new PostPaymentSessionsOperation(postPaymentSessionsOperationLink, postPaymentSessionsOperationContext, createPaymentSessionRequest());
 Response<PaymentSessions> paymentSessionsResponse = rapidClient.execute(paymentSessionsOperation);
 PaymentSessions paymentSessions = paymentSessionsResponse.getData();
 ```
@@ -198,27 +198,27 @@ CreateItineraryRequest createItineraryRequest(boolean hold) {
 
 #### Create itinerary
 ```java
-Link postItineraryLink = roomPriceCheck.getLinks().getBook(); // from the first step
+PostItineraryOperationLink postItineraryOperationLink = roomPriceCheck.getLinks().getBook(); // from the first step
 PostItineraryOperationContext postItineraryOperationContext = PostItineraryOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PostItineraryOperation itineraryCreationOperation = new PostItineraryOperation(postItineraryLink, postItineraryOperationContext, createItineraryRequest(true));
+PostItineraryOperation itineraryCreationOperation = new PostItineraryOperation(postItineraryOperationLink, postItineraryOperationContext, createItineraryRequest(true));
 Response<ItineraryCreation> response = rapidClient.execute(itineraryCreationOperation);
 ItineraryCreation itineraryCreation = response.getData();
 ```
 
 #### Complete payment session
 ```java
-Link completePaymentSessionLink = itineraryCreation.getLinks().getCompletePaymentSession();
+PutCompletePaymentSessionOperation putCompletePaymentSessionOperation = itineraryCreation.getLinks().getCompletePaymentSession();
 PutCompletePaymentSessionOperationContext putCompletePaymentSessionOperationContext = PutCompletePaymentSessionOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PutCompletePaymentSessionOperation completePaymentSessionOperation = new PutCompletePaymentSessionOperation(completePaymentSessionLink, putCompletePaymentSessionOperationContext);
+PutCompletePaymentSessionOperation completePaymentSessionOperation = new PutCompletePaymentSessionOperation(putCompletePaymentSessionOperation, putCompletePaymentSessionOperationContext);
 Response<CompletePaymentSession> completePaymentSessionResponse = rapidClient.execute(completePaymentSessionOperation);
 CompletePaymentSession completePaymentSession = completePaymentSessionResponse.getData();
 ```
 
 #### Resume on-hold booking
 ```java
-Link resumeLink = itineraryCreation.getLinks().getResume();
+PutResumeBookingOperationLink putResumeBookingOperationLink = itineraryCreation.getLinks().getResume();
 PutResumeBookingOperationContext putResumeBookingOperationContext = PutResumeBookingOperationContext.builder().customerIp("1.2.3.4").customerSessionId("12345").build(); // fill the context as needed
-PutResumeBookingOperation putResumeBookingOperation = new PutResumeBookingOperation(resumeLink, putResumeBookingOperationContext);
+PutResumeBookingOperation putResumeBookingOperation = new PutResumeBookingOperation(putResumeBookingOperationLink, putResumeBookingOperationContext);
 rapidClient.execute(putResumeBookingOperation);
 ```
 


### PR DESCRIPTION
# Situation
The links page is using the generic Link object instead of types links, the intro to the okhttpclient page needs update.

# Task
Update links and okhttpclient pages.

# Action
Updated links page
Updated usage examples to use typed links
Updated intro to okhttpclient page.

# Testing
PR preview

# Results
-

# Notes
-
