### PR TITLE
fix: remove superfluous empty line at the end of a mustache file

### DIFF
--- a/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/domains/rapid/typed_link.mustache
+++ b/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/domains/rapid/typed_link.mustache
@@ -40,4 +40,3 @@
     }
 
 {{/isLinkable}}{{/operation}}{{/operations}}
-


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
A superfluous empty line at the end of the links template file results in unused generated link files to be missed when searching for empty files (`find -empty`)

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
Remove superfluous empty line

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
Tested manually

# Results
<!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
Unused generated link files are deleted

# Notes
<!-- Add any additional context or information. This could include things like links to documentation, related issues, related PRs, follow-up tasks, edge cases considered, or potential risks. Any relevant thoughts or clarifications can go here. -->
